### PR TITLE
feat: Iron Bank TVL

### DIFF
--- a/endpoints/integrations/cream/tvl.ts
+++ b/endpoints/integrations/cream/tvl.ts
@@ -1,0 +1,21 @@
+import fetch from "node-fetch";
+
+import wrap from "../../../utils/wrap";
+
+const CreamApiURL = "https://api.cream.finance/api/v1/crtoken?comptroller=ironbank";
+
+
+type creamAssets = { [underlying_name: string]: { underlying_price: number, cash:{value:number}, underlying_name:string, token_address:string }}; // Cream assets, price, amount
+
+
+export const handler = wrap(async () => {
+
+
+  const prices = await fetch(CreamApiURL).then((res) => res.json());
+  
+  const pricesForTVL = prices.filter(prices => prices.token_address != '0x7589C9E17BCFcE1Ccaa1f921196FDa177F0207Fc') // removing the token cy3CRV as this is already taken into account in TVL V1 YEARN.
+
+  const total:creamAssets = pricesForTVL.reduce((r:number, prices) =>r + parseFloat(prices.cash.value)* parseFloat(prices.underlying_price.value),0);
+  return { IronBankTVL:total };
+  
+});

--- a/serverless.yml
+++ b/serverless.yml
@@ -76,6 +76,14 @@ functions:
           method: get
           caching:
             enabled: true
+  integrations-cream-tvl:
+    handler: endpoints/integrations/cream/tvl.handler
+    events:
+      - http:
+          path: integrations/cream/tvl
+          method: get
+          caching:
+            enabled: true
   job-vaults:
     timeout: 300
     handler: jobs/vaults.handler


### PR DESCRIPTION
fetching CREAM API data, removing double counting of the yearn cy3CRV token as this one is already considered in TVL V1.
I'm not storing anything on DB as I'm just calling CREAM API and doing some basic calculation.